### PR TITLE
PySide 6 Book, Sixth Edition: Adding missing code files for Qt Designer example (components, pages 187, 188, 189, 190)

### DIFF
--- a/create-gui-applications/pyside6/designer/component_app.py
+++ b/create-gui-applications/pyside6/designer/component_app.py
@@ -1,0 +1,30 @@
+import sys
+
+from componenta import ComponentA
+from componentb import ComponentB
+from mainwindow_tabs_ui import Ui_MainWindow
+
+from PySide6.QtWidgets import QApplication, QMainWindow
+
+class MainWindow(QMainWindow, Ui_MainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setupUi(self)
+
+        self.component_a = ComponentA()
+        self.component_b = ComponentB()
+
+        # Get central widget from window.
+        widget = self.centralWidget()
+
+        # Get layout from central Widget.
+        layout = widget.layout()
+
+        layout.addWidget(self.component_a)
+        layout.addWidget(self.component_b)
+
+
+app = QApplication(sys.argv)
+window = MainWindow()
+window.show()
+app.exec()

--- a/create-gui-applications/pyside6/designer/componenta.py
+++ b/create-gui-applications/pyside6/designer/componenta.py
@@ -1,0 +1,14 @@
+from componenta_ui import Ui_ComponentA
+
+from PySide6.QtWidgets import QWidget
+
+class ComponentA(QWidget, Ui_ComponentA):
+    def __init__(self):
+        super().__init__()
+        self.setupUi(self)
+        self.lineEdit.textChanged.connect(
+            self.handle_lineedit_changed
+        )
+
+    def handle_lineedit_changed(self, s):
+        print(s)

--- a/create-gui-applications/pyside6/designer/componenta.ui
+++ b/create-gui-applications/pyside6/designer/componenta.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ComponentA</class>
+ <widget class="QWidget" name="ComponentA">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>388</width>
+    <height>333</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLineEdit" name="lineEdit"/>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="spinBox"/>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="textEdit"/>
+   </item>
+   <item>
+    <widget class="QDoubleSpinBox" name="doubleSpinBox"/>
+   </item>
+   <item>
+    <widget class="QSlider" name="horizontalSlider">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/create-gui-applications/pyside6/designer/componenta_ui.py
+++ b/create-gui-applications/pyside6/designer/componenta_ui.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'componenta.ui'
+##
+## Created by: Qt User Interface Compiler version 6.8.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QDoubleSpinBox, QLineEdit, QSizePolicy,
+    QSlider, QSpinBox, QTextEdit, QVBoxLayout,
+    QWidget)
+
+class Ui_ComponentA(object):
+    def setupUi(self, ComponentA):
+        if not ComponentA.objectName():
+            ComponentA.setObjectName(u"ComponentA")
+        ComponentA.resize(388, 333)
+        self.verticalLayout = QVBoxLayout(ComponentA)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.lineEdit = QLineEdit(ComponentA)
+        self.lineEdit.setObjectName(u"lineEdit")
+
+        self.verticalLayout.addWidget(self.lineEdit)
+
+        self.spinBox = QSpinBox(ComponentA)
+        self.spinBox.setObjectName(u"spinBox")
+
+        self.verticalLayout.addWidget(self.spinBox)
+
+        self.textEdit = QTextEdit(ComponentA)
+        self.textEdit.setObjectName(u"textEdit")
+
+        self.verticalLayout.addWidget(self.textEdit)
+
+        self.doubleSpinBox = QDoubleSpinBox(ComponentA)
+        self.doubleSpinBox.setObjectName(u"doubleSpinBox")
+
+        self.verticalLayout.addWidget(self.doubleSpinBox)
+
+        self.horizontalSlider = QSlider(ComponentA)
+        self.horizontalSlider.setObjectName(u"horizontalSlider")
+        self.horizontalSlider.setOrientation(Qt.Orientation.Horizontal)
+
+        self.verticalLayout.addWidget(self.horizontalSlider)
+
+
+        self.retranslateUi(ComponentA)
+
+        QMetaObject.connectSlotsByName(ComponentA)
+    # setupUi
+
+    def retranslateUi(self, ComponentA):
+        ComponentA.setWindowTitle(QCoreApplication.translate("ComponentA", u"Form", None))
+    # retranslateUi
+

--- a/create-gui-applications/pyside6/designer/componentb.py
+++ b/create-gui-applications/pyside6/designer/componentb.py
@@ -1,0 +1,12 @@
+from componentb_ui import Ui_ComponentB
+
+from PySide6.QtWidgets import QWidget
+
+class ComponentB(QWidget, Ui_ComponentB):
+    def __init__(self):
+        super().__init__()
+        self.setupUi(self)
+        self.dial.valueChanged.connect(self.handle_dial_changed)
+
+    def handle_dial_changed(self, value):
+        print(value)

--- a/create-gui-applications/pyside6/designer/componentb.ui
+++ b/create-gui-applications/pyside6/designer/componentb.ui
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ComponentB</class>
+ <widget class="QWidget" name="ComponentB">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>168</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QSpinBox" name="spinBox"/>
+   </item>
+   <item>
+    <widget class="QTimeEdit" name="timeEdit"/>
+   </item>
+   <item>
+    <widget class="QDateEdit" name="dateEdit"/>
+   </item>
+   <item>
+    <widget class="QDial" name="dial"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/create-gui-applications/pyside6/designer/componentb_ui.py
+++ b/create-gui-applications/pyside6/designer/componentb_ui.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'componentb.ui'
+##
+## Created by: Qt User Interface Compiler version 6.8.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QDateEdit, QDial, QSizePolicy,
+    QSpinBox, QTimeEdit, QVBoxLayout, QWidget)
+
+class Ui_ComponentB(object):
+    def setupUi(self, ComponentB):
+        if not ComponentB.objectName():
+            ComponentB.setObjectName(u"ComponentB")
+        ComponentB.resize(168, 300)
+        self.verticalLayout = QVBoxLayout(ComponentB)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.spinBox = QSpinBox(ComponentB)
+        self.spinBox.setObjectName(u"spinBox")
+
+        self.verticalLayout.addWidget(self.spinBox)
+
+        self.timeEdit = QTimeEdit(ComponentB)
+        self.timeEdit.setObjectName(u"timeEdit")
+
+        self.verticalLayout.addWidget(self.timeEdit)
+
+        self.dateEdit = QDateEdit(ComponentB)
+        self.dateEdit.setObjectName(u"dateEdit")
+
+        self.verticalLayout.addWidget(self.dateEdit)
+
+        self.dial = QDial(ComponentB)
+        self.dial.setObjectName(u"dial")
+
+        self.verticalLayout.addWidget(self.dial)
+
+
+        self.retranslateUi(ComponentB)
+
+        QMetaObject.connectSlotsByName(ComponentB)
+    # setupUi
+
+    def retranslateUi(self, ComponentB):
+        ComponentB.setWindowTitle(QCoreApplication.translate("ComponentB", u"Form", None))
+    # retranslateUi
+

--- a/create-gui-applications/pyside6/designer/mainwindow_tabs.ui
+++ b/create-gui-applications/pyside6/designer/mainwindow_tabs.ui
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1106</width>
+    <height>819</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
+     <widget class="QWidget" name="widget" native="true"/>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>1106</width>
+     <height>33</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/create-gui-applications/pyside6/designer/mainwindow_tabs_ui.py
+++ b/create-gui-applications/pyside6/designer/mainwindow_tabs_ui.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'mainwindow_tabs.ui'
+##
+## Created by: Qt User Interface Compiler version 6.8.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QHBoxLayout, QMainWindow, QMenuBar,
+    QSizePolicy, QStatusBar, QWidget)
+
+class Ui_MainWindow(object):
+    def setupUi(self, MainWindow):
+        if not MainWindow.objectName():
+            MainWindow.setObjectName(u"MainWindow")
+        MainWindow.resize(1106, 819)
+        self.centralwidget = QWidget(MainWindow)
+        self.centralwidget.setObjectName(u"centralwidget")
+        self.horizontalLayout = QHBoxLayout(self.centralwidget)
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.widget = QWidget(self.centralwidget)
+        self.widget.setObjectName(u"widget")
+
+        self.horizontalLayout.addWidget(self.widget)
+
+        MainWindow.setCentralWidget(self.centralwidget)
+        self.menubar = QMenuBar(MainWindow)
+        self.menubar.setObjectName(u"menubar")
+        self.menubar.setGeometry(QRect(0, 0, 1106, 33))
+        MainWindow.setMenuBar(self.menubar)
+        self.statusbar = QStatusBar(MainWindow)
+        self.statusbar.setObjectName(u"statusbar")
+        MainWindow.setStatusBar(self.statusbar)
+
+        self.retranslateUi(MainWindow)
+
+        QMetaObject.connectSlotsByName(MainWindow)
+    # setupUi
+
+    def retranslateUi(self, MainWindow):
+        MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"MainWindow", None))
+    # retranslateUi
+


### PR DESCRIPTION
While working through the PySide 6 (Sixth Edition) book, I found several example source code and ui files are missing for the Qt Designer example starting on page 188 listing 99, page 189/190 listing 100/101.

Also, the ui and generated code files for mainwindow_tabs_ui referenced in listing 99 (component_app.py) do not exist.

Thanks for all the great work.